### PR TITLE
Clean up routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: "timelines#index"
-  
-  devise_for :users 
-  resources :timelines
-  
+
+  devise_for :users
+  resources :timelines, only: [:index]
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160117172518) do
+ActiveRecord::Schema.define(version: 20160118000351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
In the judging criteria they will judge the apps based on a number of criteria, largely viewing it as we
would any client app. One of them is clean RESTful routing that's the reason I maked the change.