### PR TITLE
rake db:migrate error fix: add foreign key after users table created

### DIFF
--- a/db/migrate/20160121085858_create_photos.rb
+++ b/db/migrate/20160121085858_create_photos.rb
@@ -9,6 +9,5 @@ class CreatePhotos < ActiveRecord::Migration
     end
 
     add_index :photos, :user_id
-    add_foreign_key :photos, :users, name: "fk_users_photo"
   end
 end

--- a/db/migrate/20160131175604_add_foreign_key_users_to_photo.rb
+++ b/db/migrate/20160131175604_add_foreign_key_users_to_photo.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyUsersToPhoto < ActiveRecord::Migration
+  def change
+    add_foreign_key :photos, :users, name: "fk_users_photo"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160130123855) do
+ActiveRecord::Schema.define(version: 20160131175604) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,4 +59,5 @@ ActiveRecord::Schema.define(version: 20160130123855) do
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
 
+  add_foreign_key "photos", "users", name: "fk_users_photo"
 end


### PR DESCRIPTION
#15 

When I forked the project, created the db and ran `rake db:migrate`, I was receiving the error described in #15. This is because the foreign key was being added prior to the `users` table being created. This is now fixed, so when thoughtbot forks our project, they will be able to create the databases without a problem.